### PR TITLE
fix(FullPlayButton): add cursor-pointer class to FullPlayButton

### DIFF
--- a/src/components/FullPlayButton.tsx
+++ b/src/components/FullPlayButton.tsx
@@ -58,7 +58,7 @@ export default function FullPlayButton({ episode }: Props) {
 
   return (
     <button
-      class="btn"
+      class="btn cursor-pointer"
       onClick={() => {
         currentEpisode.value = {
           ...episode


### PR DESCRIPTION
Added cursor pointer (I think button should show by default but this is not happening) for better UX

Before:

<img width="1512" height="823" alt="Screenshot 2025-09-12 at 11 01 39" src="https://github.com/user-attachments/assets/905d2919-87c9-4287-ba89-987dccef19a6" />

After:

It should appear with the cursor pointer I couldn't make a screenshot 🤦🏼‍♂️ 
