### PR TITLE
Make timestamps in transcripts clickable, use RSS transcripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,14 @@ connection is configured in `db/index.ts`.
 - `src/lib/` — Core utilities: RSS fetching, image optimization, LLM content
   generation.
 - `src/content/transcripts/` — Markdown transcript files named by episode
-  number.
+  number. When one is absent, the site falls back to the transcript referenced
+  by the feed's `<podcast:transcript>` tag (fetched/parsed in
+  `src/lib/transcript.ts`). Both sources render with clickable timestamps that
+  seek the player: RSS paragraphs via the `episode/Transcript` island, and
+  markdown `[HH:MM:SS]` timestamps via the `rehype-transcript-timestamps`
+  plugin (registered in `astro.config.mjs`) plus the `episode/MarkdownTranscript`
+  island. Note: changing that rehype plugin needs a dev server restart to take
+  effect, since Astro's content render cache doesn't reload it on hot-reload.
 - `src/layouts/Layout.astro` — Single shared layout.
 - `db/` — Database schema (`schema.ts`), connection (`index.ts`), seed script
   (`seed.ts`), and static data files (`data/`).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,8 @@ import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 import vercel from '@astrojs/vercel';
 
+import rehypeTranscriptTimestamps from './src/lib/rehype-transcript-timestamps.mjs';
+
 // https://astro.build/config
 export default defineConfig({
   output: 'static',
@@ -28,6 +30,10 @@ export default defineConfig({
   }),
   build: {
     inlineStylesheets: 'always'
+  },
+  markdown: {
+    // Makes bracketed timestamps in markdown transcripts clickable for seeking.
+    rehypePlugins: [rehypeTranscriptTimestamps]
   },
   experimental: {
     clientPrerender: true

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -71,11 +71,20 @@ export default function Player() {
       return;
     }
 
-    const applySeek = () => {
+    const applySeek = async () => {
+      const previousIsPlaying = isPlaying.value;
+      const previousSeekTo = seekTo.value;
       player.currentTime = target;
-      isPlaying.value = true;
-      player.play();
-      seekTo.value = null;
+      try {
+        await player.play();
+        isPlaying.value = true;
+        seekTo.value = null;
+      } catch {
+        // Playback was blocked (e.g. autoplay policy) — keep the UI honest by
+        // restoring the pre-seek state instead of showing a false "playing".
+        isPlaying.value = previousIsPlaying;
+        seekTo.value = previousSeekTo;
+      }
     };
 
     // If the episode was just switched, its metadata isn't loaded yet and the

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'preact/hooks';
 
-import { currentEpisode, isMuted, isPlaying } from '../components/state';
+import { currentEpisode, isMuted, isPlaying, seekTo } from '../components/state';
 import MuteButton from './player/MuteButton';
 import PlayButton from './player/PlayButton';
 import PlaybackRateButton from './player/PlaybackRateButton';
@@ -63,6 +63,30 @@ export default function Player() {
       cancelAnimationFrame(progressRef.current as number);
     }
   }, [isPlaying.value]);
+
+  useEffect(() => {
+    const target = seekTo.value;
+    const player = audioPlayer.current;
+    if (target === null || !player) {
+      return;
+    }
+
+    const applySeek = () => {
+      player.currentTime = target;
+      isPlaying.value = true;
+      player.play();
+      seekTo.value = null;
+    };
+
+    // If the episode was just switched, its metadata isn't loaded yet and the
+    // seek wouldn't stick — wait for it. Otherwise seek immediately.
+    if (player.readyState >= 1 /* HAVE_METADATA */) {
+      applySeek();
+    } else {
+      player.addEventListener('loadedmetadata', applySeek, { once: true });
+      return () => player.removeEventListener('loadedmetadata', applySeek);
+    }
+  }, [seekTo.value]);
 
   useEffect(() => {
     const duration = audioPlayer.current?.duration ?? 0;

--- a/src/components/episode/MarkdownTranscript.tsx
+++ b/src/components/episode/MarkdownTranscript.tsx
@@ -1,0 +1,39 @@
+import type { ComponentChildren, JSX } from 'preact';
+
+import { currentEpisode, seekToEpisode } from '../state';
+
+type Props = {
+  episode: NonNullable<(typeof currentEpisode)['value']>;
+  children: ComponentChildren;
+};
+
+/**
+ * Wraps a server-rendered markdown transcript and makes its timestamp buttons
+ * (injected by the `rehype-transcript-timestamps` plugin) seek the player.
+ *
+ * The markdown HTML is rendered by Astro and passed in as children, so a single
+ * delegated click handler on the container drives every `[data-seek]` button
+ * rather than hydrating each one.
+ */
+export default function MarkdownTranscript({ episode, children }: Props) {
+  function handleClick(event: JSX.TargetedMouseEvent<HTMLElement>) {
+    const button = (event.target as HTMLElement).closest('[data-seek]');
+    if (!button) {
+      return;
+    }
+
+    const seconds = Number(button.getAttribute('data-seek'));
+    if (Number.isFinite(seconds)) {
+      seekToEpisode(episode, seconds);
+    }
+  }
+
+  return (
+    <article
+      class="transcript prose prose-neutral dark:prose-invert line-clamp-4"
+      onClick={handleClick}
+    >
+      {children}
+    </article>
+  );
+}

--- a/src/components/episode/Transcript.tsx
+++ b/src/components/episode/Transcript.tsx
@@ -1,0 +1,54 @@
+import { currentEpisode, seekToEpisode } from '../state';
+import type { TranscriptParagraph } from '../../lib/transcript';
+
+type Props = {
+  episode: NonNullable<(typeof currentEpisode)['value']>;
+  paragraphs: Array<TranscriptParagraph>;
+};
+
+function formatTimestamp(seconds: number): string {
+  const total = Math.floor(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  const pad = (value: number) => value.toString().padStart(2, '0');
+
+  return hours > 0
+    ? `${hours}:${pad(minutes)}:${pad(secs)}`
+    : `${minutes}:${pad(secs)}`;
+}
+
+/**
+ * Renders an RSS-sourced transcript as paragraphs, each prefixed with a
+ * clickable timestamp that jumps the audio player to that moment (starting the
+ * episode first if it isn't the one currently loaded).
+ */
+export default function Transcript({ episode, paragraphs }: Props) {
+  function jumpTo(start: number) {
+    seekToEpisode(episode, start);
+  }
+
+  return (
+    <article class="transcript prose prose-neutral dark:prose-invert line-clamp-4">
+      {paragraphs.map((paragraph, index) => {
+        const start = paragraph.start;
+
+        return (
+          <p key={index}>
+            {start !== undefined && (
+              <button
+                type="button"
+                onClick={() => jumpTo(start)}
+                class="mr-2 align-baseline font-mono text-sm font-medium text-violet-600 tabular-nums no-underline transition-colors hover:text-violet-500 dark:text-cyan-400 dark:hover:text-cyan-300"
+                aria-label={`Play from ${formatTimestamp(start)}`}
+              >
+                {formatTimestamp(start)}
+              </button>
+            )}
+            {paragraph.text}
+          </p>
+        );
+      })}
+    </article>
+  );
+}

--- a/src/components/state.ts
+++ b/src/components/state.ts
@@ -8,5 +8,22 @@ export const currentEpisode = signal<Pick<
 export const isPlaying = signal(false);
 export const isMuted = signal(false);
 
+// Set to a time (in seconds) to ask the player to seek there. The player
+// consumes it and resets it back to null. Used by clickable transcript
+// timestamps to jump to a moment in the current episode.
+export const seekTo = signal<number | null>(null);
+
+// Load the given episode (if it isn't already current) and ask the player to
+// seek to `seconds`. Shared by the RSS and markdown transcript timestamps.
+export function seekToEpisode(
+  episode: NonNullable<(typeof currentEpisode)['value']>,
+  seconds: number
+) {
+  if (currentEpisode.value?.id !== episode.id) {
+    currentEpisode.value = { ...episode };
+  }
+  seekTo.value = seconds;
+}
+
 // Search state
 export const isSearchOpen = signal(false);

--- a/src/lib/rehype-transcript-timestamps.mjs
+++ b/src/lib/rehype-transcript-timestamps.mjs
@@ -1,0 +1,101 @@
+// Rehype plugin that turns bracketed transcript timestamps like `[00:01:23]`
+// or `[04:12]` into clickable buttons that seek the audio player. Only the
+// markdown transcripts in `src/content/transcripts` contain this pattern, so
+// this plugin effectively only affects them.
+//
+// The button keeps the original bracketed label as its text and carries the
+// resolved offset (in seconds) in `data-seek`; the client-side markdown
+// transcript island reads that attribute to drive the player. The class list
+// mirrors the RSS transcript timestamps (`Transcript.tsx`) so both look the
+// same. Those utilities are already emitted by Tailwind from that component,
+// so listing them here adds no new CSS.
+const TIMESTAMP = /\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]/g;
+
+const TIMESTAMP_CLASS = [
+  'transcript-timestamp',
+  'mr-1',
+  'align-baseline',
+  'font-mono',
+  'text-sm',
+  'font-medium',
+  'text-violet-600',
+  'tabular-nums',
+  'no-underline',
+  'transition-colors',
+  'hover:text-violet-500',
+  'dark:text-cyan-400',
+  'dark:hover:text-cyan-300'
+];
+
+function toSeconds(hours, minutes, seconds) {
+  // `[MM:SS]` arrives as (minutes, seconds) with `seconds` undefined.
+  return seconds === undefined
+    ? Number(hours) * 60 + Number(minutes)
+    : Number(hours) * 3600 + Number(minutes) * 60 + Number(seconds);
+}
+
+function timestampButton(label, seconds) {
+  return {
+    type: 'element',
+    tagName: 'button',
+    properties: {
+      type: 'button',
+      className: [...TIMESTAMP_CLASS],
+      'data-seek': String(seconds),
+      'aria-label': `Play from ${label}`
+    },
+    children: [{ type: 'text', value: label }]
+  };
+}
+
+function splitTextNode(value) {
+  const nodes = [];
+  let lastIndex = 0;
+  let match;
+
+  TIMESTAMP.lastIndex = 0;
+  while ((match = TIMESTAMP.exec(value)) !== null) {
+    const [label, a, b, c] = match;
+    if (match.index > lastIndex) {
+      nodes.push({ type: 'text', value: value.slice(lastIndex, match.index) });
+    }
+    nodes.push(timestampButton(label, toSeconds(a, b, c)));
+    lastIndex = match.index + label.length;
+  }
+
+  if (lastIndex < value.length) {
+    nodes.push({ type: 'text', value: value.slice(lastIndex) });
+  }
+
+  return nodes;
+}
+
+function transform(node) {
+  if (!node.children || node.children.length === 0) {
+    return;
+  }
+
+  const nextChildren = [];
+  for (const child of node.children) {
+    if (
+      child.type === 'text' &&
+      // Cheap guard so we only rebuild text nodes that actually contain a
+      // timestamp.
+      child.value.includes('[') &&
+      TIMESTAMP.test(child.value)
+    ) {
+      nextChildren.push(...splitTextNode(child.value));
+    } else {
+      transform(child);
+      nextChildren.push(child);
+    }
+  }
+
+  node.children = nextChildren;
+}
+
+export default function rehypeTranscriptTimestamps() {
+  return (tree) => {
+    transform(tree);
+  };
+}

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -152,7 +152,7 @@ export async function getAllEpisodes() {
           const transcript = pickTranscript(podcast_transcript);
           const audioEnclosure =
             enclosures.find((enclosure) =>
-              enclosure.type?.startsWith('audio')
+              enclosure.type?.toLowerCase().startsWith('audio/')
             ) ?? enclosures[0];
 
           return {

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,6 +1,14 @@
 import { htmlToText } from 'html-to-text';
 import parseFeed from 'rss-to-json';
-import { array, number, object, optional, parse, string } from 'valibot';
+import {
+  array,
+  number,
+  object,
+  optional,
+  parse,
+  string,
+  union
+} from 'valibot';
 
 import { optimizeImage } from './optimize-episode-image';
 import { dasherize } from '../utils/dasherize';
@@ -29,6 +37,40 @@ export interface Episode {
     src: string;
     type: string;
   };
+  // A transcript referenced by the feed's `<podcast:transcript>` tag, if any.
+  // Used as a fallback when no explicit markdown transcript is provided for the
+  // episode.
+  transcriptUrl?: string;
+  transcriptType?: string;
+}
+
+// A single `<podcast:transcript>` entry from the RSS feed.
+const TranscriptSchema = object({
+  url: string(),
+  type: optional(string()),
+  language: optional(string()),
+  rel: optional(string())
+});
+
+// A feed may list zero, one, or several transcripts per episode. Prefer a JSON
+// transcript (Flightcast's format), then VTT, then whatever comes first.
+function pickTranscript(
+  transcript:
+    | { url: string; type?: string }
+    | Array<{ url: string; type?: string }>
+    | undefined
+) {
+  if (!transcript) {
+    return undefined;
+  }
+
+  const list = Array.isArray(transcript) ? transcript : [transcript];
+
+  return (
+    list.find((t) => t.type?.toLowerCase().includes('json')) ??
+    list.find((t) => t.type?.toLowerCase().includes('vtt')) ??
+    list[0]
+  );
 }
 
 let showInfoCache: Show | null = null;
@@ -63,14 +105,19 @@ export async function getAllEpisodes() {
         published: number(),
         description: string(),
         content_encoded: optional(string()),
+        podcast_transcript: optional(
+          union([TranscriptSchema, array(TranscriptSchema)])
+        ),
         itunes_duration: number(),
         itunes_episode: optional(number()),
         itunes_episodeType: string(),
         itunes_image: optional(object({ href: optional(string()) })),
+        // A feed may list several enclosures (e.g. the audio file plus a
+        // generated cover image); the image enclosure has no `type`.
         enclosures: array(
           object({
             url: string(),
-            type: string()
+            type: optional(string())
           })
         )
       })
@@ -92,6 +139,7 @@ export async function getAllEpisodes() {
           title,
           enclosures,
           published,
+          podcast_transcript,
           itunes_duration,
           itunes_episode,
           itunes_episodeType,
@@ -101,6 +149,11 @@ export async function getAllEpisodes() {
             itunes_episodeType === 'bonus' ? 'Bonus' : `${itunes_episode}`;
           const episodeSlug = dasherize(title);
           const episodeContent = content_encoded || description;
+          const transcript = pickTranscript(podcast_transcript);
+          const audioEnclosure =
+            enclosures.find((enclosure) =>
+              enclosure.type?.startsWith('audio')
+            ) ?? enclosures[0];
 
           return {
             id,
@@ -113,10 +166,12 @@ export async function getAllEpisodes() {
             episodeSlug,
             episodeThumbnail: await optimizeImage(itunes_image?.href),
             published,
-            audio: enclosures.map((enclosure) => ({
-              src: enclosure.url,
-              type: enclosure.type
-            }))[0]
+            transcriptUrl: transcript?.url,
+            transcriptType: transcript?.type,
+            audio: {
+              src: audioEnclosure.url,
+              type: audioEnclosure.type ?? 'audio/mpeg'
+            }
           };
         }
       )

--- a/src/lib/transcript.ts
+++ b/src/lib/transcript.ts
@@ -1,0 +1,164 @@
+import type { Episode } from './rss';
+
+// Roughly how many characters to accumulate before starting a new paragraph
+// when grouping transcript segments. Auto-generated transcripts have no real
+// paragraph boundaries, so we group short segments into readable chunks.
+const PARAGRAPH_TARGET_CHARS = 600;
+
+// A paragraph of transcript text, optionally tagged with the time (in seconds)
+// at which it begins so the UI can offer a "jump to this moment" control.
+export interface TranscriptParagraph {
+  start?: number;
+  text: string;
+}
+
+interface JsonTranscript {
+  text?: string;
+  segments?: Array<{ text?: string; start?: number }>;
+}
+
+// Cache parsed transcripts by URL so the episode page and its `.html.md`
+// counterpart don't fetch the same transcript twice during a build.
+const cache = new Map<string, Array<TranscriptParagraph> | null>();
+
+/**
+ * Fetch the transcript referenced by the episode's RSS `<podcast:transcript>`
+ * tag and return it as an array of paragraphs (each with an optional start
+ * time). Returns `null` when the episode has no RSS transcript, or when it
+ * can't be fetched or parsed.
+ */
+export async function getRssTranscriptParagraphs(
+  episode: Episode
+): Promise<Array<TranscriptParagraph> | null> {
+  const url = episode.transcriptUrl;
+  if (!url) {
+    return null;
+  }
+
+  const cached = cache.get(url);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let paragraphs: Array<TranscriptParagraph> | null = null;
+
+  try {
+    const response = await fetch(url);
+    if (response.ok) {
+      const raw = await response.text();
+      const type =
+        episode.transcriptType || response.headers.get('content-type') || '';
+      paragraphs = parseTranscript(raw, type);
+    }
+  } catch {
+    paragraphs = null;
+  }
+
+  cache.set(url, paragraphs);
+  return paragraphs;
+}
+
+/**
+ * Same as `getRssTranscriptParagraphs`, but joined into a single markdown/plain
+ * text string (paragraphs separated by blank lines). Returns `null` when no
+ * usable transcript is available.
+ */
+export async function getRssTranscriptText(
+  episode: Episode
+): Promise<string | null> {
+  const paragraphs = await getRssTranscriptParagraphs(episode);
+  return paragraphs?.length
+    ? paragraphs.map((paragraph) => paragraph.text).join('\n\n')
+    : null;
+}
+
+function parseTranscript(
+  raw: string,
+  type: string
+): Array<TranscriptParagraph> | null {
+  const lower = type.toLowerCase();
+
+  if (lower.includes('json')) {
+    let data: JsonTranscript;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+
+    if (Array.isArray(data.segments) && data.segments.length > 0) {
+      const segments: Array<{ text: string; start?: number }> = [];
+      for (const segment of data.segments) {
+        const text = segment.text?.trim();
+        if (text) {
+          segments.push({ text, start: segment.start });
+        }
+      }
+      if (segments.length > 0) {
+        return groupSegments(segments);
+      }
+    }
+
+    if (typeof data.text === 'string' && data.text.trim()) {
+      return splitParagraphs(data.text);
+    }
+
+    return null;
+  }
+
+  // VTT, SRT, or plain text: strip cue metadata and fall back to paragraph
+  // splitting on blank lines. Timing information isn't recovered here.
+  const stripped = stripCues(raw);
+  return stripped ? splitParagraphs(stripped) : null;
+}
+
+/**
+ * Group fine-grained transcript segments into readable paragraphs, breaking
+ * once a paragraph reaches roughly `PARAGRAPH_TARGET_CHARS`. Each paragraph is
+ * tagged with the start time of its first segment.
+ */
+function groupSegments(
+  segments: Array<{ text: string; start?: number }>
+): Array<TranscriptParagraph> {
+  const paragraphs: Array<TranscriptParagraph> = [];
+  let current = '';
+  let start: number | undefined;
+
+  for (const segment of segments) {
+    if (!current) {
+      start = segment.start;
+    }
+    current = current ? `${current} ${segment.text}` : segment.text;
+    if (current.length >= PARAGRAPH_TARGET_CHARS) {
+      paragraphs.push({ start, text: current });
+      current = '';
+    }
+  }
+
+  if (current) {
+    paragraphs.push({ start, text: current });
+  }
+
+  return paragraphs;
+}
+
+function splitParagraphs(text: string): Array<TranscriptParagraph> {
+  return text
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+    .map((paragraph) => ({ text: paragraph }));
+}
+
+/**
+ * Remove WebVTT/SRT scaffolding (the `WEBVTT` header, numeric cue indexes, and
+ * `00:00:00.000 --> 00:00:00.000` timing lines), leaving just the spoken text.
+ */
+function stripCues(raw: string): string {
+  return raw
+    .replace(/^WEBVTT.*$/gim, '')
+    .replace(/^\d+\s*$/gm, '')
+    .replace(/^.*-->.*$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/src/lib/transcript.ts
+++ b/src/lib/transcript.ts
@@ -106,10 +106,67 @@ function parseTranscript(
     return null;
   }
 
-  // VTT, SRT, or plain text: strip cue metadata and fall back to paragraph
-  // splitting on blank lines. Timing information isn't recovered here.
+  // VTT or SRT: parse cue blocks, keeping each cue's start time so the
+  // timestamps stay clickable, then group them like JSON segments.
+  const cues = parseCues(raw);
+  if (cues.length > 0) {
+    return groupSegments(cues);
+  }
+
+  // Plain text (or unparseable cues): strip any leftover cue metadata and fall
+  // back to paragraph splitting on blank lines. Timing isn't recoverable here.
   const stripped = stripCues(raw);
   return stripped ? splitParagraphs(stripped) : null;
+}
+
+/**
+ * Parse WebVTT/SRT cue blocks into `{ start, text }` entries, preserving the
+ * start time (in seconds) of each cue. Blocks without a `-->` timing line
+ * (e.g. the `WEBVTT` header) are skipped.
+ */
+function parseCues(raw: string): Array<{ text: string; start: number }> {
+  const cues: Array<{ text: string; start: number }> = [];
+
+  for (const block of raw.replace(/\r\n/g, '\n').split(/\n{2,}/)) {
+    const lines = block
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const timingIndex = lines.findIndex((line) => line.includes('-->'));
+    if (timingIndex === -1) {
+      continue;
+    }
+
+    const start = parseCueStart(lines[timingIndex]);
+    // Cue text is everything after the timing line (the numeric index and any
+    // cue identifier come before it).
+    const text = lines.slice(timingIndex + 1).join(' ').trim();
+    if (start !== undefined && text) {
+      cues.push({ text, start });
+    }
+  }
+
+  return cues;
+}
+
+/**
+ * Parse the start timestamp from a cue's timing line, supporting
+ * `HH:MM:SS.mmm` / `MM:SS.mmm` (VTT) and comma-delimited SRT milliseconds.
+ */
+function parseCueStart(timingLine: string): number | undefined {
+  const startPart = timingLine.split('-->')[0];
+  const match = startPart.match(/(?:(\d+):)?(\d{1,2}):(\d{2})(?:[.,](\d{1,3}))?/);
+  if (!match) {
+    return undefined;
+  }
+
+  const [, hours, minutes, seconds, milliseconds] = match;
+  return (
+    (hours ? Number(hours) * 3600 : 0) +
+    Number(minutes) * 60 +
+    Number(seconds) +
+    (milliseconds ? Number(milliseconds) / 1000 : 0)
+  );
 }
 
 /**

--- a/src/pages/[episode].astro
+++ b/src/pages/[episode].astro
@@ -16,6 +16,8 @@ import { Schema } from 'astro-seo-schema';
 import FormattedDate from '../components/FormattedDate';
 import CreatorsAndGuests from '../components/episode/CreatorsAndGuests.astro';
 import Sponsors from '../components/episode/Sponsors.astro';
+import MarkdownTranscript from '../components/episode/MarkdownTranscript';
+import RssTranscript from '../components/episode/Transcript';
 import PlayButton from '../components/player/PlayButton';
 import FullPlayButton from '../components/FullPlayButton';
 import UFOIllustration from '../components/illustrations/UFOIllustration.astro';
@@ -23,6 +25,10 @@ import { generateDocumentLinkTag } from '@bryanguffey/astro-standard-site';
 
 import Layout from '../layouts/Layout.astro';
 import { getAllEpisodes, getShowInfo } from '../lib/rss';
+import {
+  getRssTranscriptParagraphs,
+  type TranscriptParagraph
+} from '../lib/transcript';
 import { getDocumentRkeys } from '../lib/standardSite';
 import { dasherize } from '../utils/dasherize';
 
@@ -48,6 +54,7 @@ export async function getStaticPaths() {
 const { episode } = Astro.props;
 
 let Transcript;
+let rssTranscript: Array<TranscriptParagraph> | null = null;
 
 if (episode.episodeNumber && episode.episodeNumber !== 'Bonus') {
   Transcript = await getEntry('transcripts', episode.episodeNumber);
@@ -56,6 +63,23 @@ if (episode.episodeNumber && episode.episodeNumber !== 'Bonus') {
     Transcript = Content;
   }
 }
+
+// Fall back to the transcript referenced by the RSS feed's
+// `<podcast:transcript>` tag when no explicit markdown transcript was provided.
+if (!Transcript) {
+  rssTranscript = await getRssTranscriptParagraphs(episode);
+}
+
+const hasTranscript = Boolean(Transcript) || Boolean(rssTranscript?.length);
+
+// The subset of episode fields the player needs, shared by both transcript
+// timestamp variants so clicking one can load this episode.
+const playerEpisode = {
+  audio: episode.audio,
+  episodeNumber: episode.episodeNumber,
+  id: episode.id,
+  title: episode.title
+};
 
 const canonicalURL = new URL(`/${episode.episodeSlug}`, Astro.url);
 
@@ -212,7 +236,7 @@ const documentLinkTag =
         </h3>
 
         {
-          Transcript ? (
+          hasTranscript ? (
             <div class="mb-20">
               <Schema
                 item={{
@@ -239,9 +263,19 @@ const documentLinkTag =
                   }
                 }}
               />
-              <article class="transcript prose prose-neutral dark:prose-invert line-clamp-4">
-                <Transcript />
-              </article>
+              {
+                Transcript ? (
+                  <MarkdownTranscript client:load episode={playerEpisode}>
+                    <Transcript />
+                  </MarkdownTranscript>
+                ) : (
+                  <RssTranscript
+                    client:load
+                    episode={playerEpisode}
+                    paragraphs={rssTranscript!}
+                  />
+                )
+              }
 
               <button
                 class="btn mt-4"

--- a/src/pages/[episode].html.md.ts
+++ b/src/pages/[episode].html.md.ts
@@ -3,6 +3,7 @@ import type { APIRoute } from 'astro';
 
 import { cleanTranscript, generateEpisodeMarkdown } from '../lib/llms';
 import { getAllEpisodes, getShowInfo } from '../lib/rss';
+import { getRssTranscriptText } from '../lib/transcript';
 import starpodConfig from '../../starpod.config';
 
 export async function getStaticPaths() {
@@ -34,6 +35,12 @@ export const GET: APIRoute = async ({ props }) => {
       // Clean the transcript by removing timestamps
       transcriptContent = cleanTranscript(transcript.body);
     }
+  }
+
+  // Fall back to the RSS feed's `<podcast:transcript>` when no explicit
+  // markdown transcript exists for this episode.
+  if (!transcriptContent) {
+    transcriptContent = (await getRssTranscriptText(episode)) || '';
   }
 
   const markdown = generateEpisodeMarkdown(

--- a/tests/e2e/episode.spec.ts
+++ b/tests/e2e/episode.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 const episode1 = {
   title:
@@ -81,4 +81,73 @@ test('works for bonus episodes with no episode number', async ({ page }) => {
 
   const twitterImage = page.locator('meta[name="twitter:image:src"]');
   await expect(twitterImage).toHaveAttribute('content', episode2.image);
+});
+
+test.describe('transcripts', () => {
+  const timestampButtons = (page: Page) =>
+    page.getByRole('button', { name: /^Play from/ });
+
+  // Episode 6 has no markdown transcript in src/content/transcripts, so it
+  // falls back to the transcript referenced by the feed's <podcast:transcript>
+  // tag. Those timestamps are compact (e.g. "0:04"), with no brackets.
+  test('falls back to the RSS transcript with clickable timestamps when no markdown exists', async ({
+    page
+  }) => {
+    await page.goto('/6');
+
+    await expect(
+      page.getByRole('heading', { name: 'Episode Transcript' })
+    ).toBeVisible();
+    await expect(page.locator('article.transcript')).not.toBeEmpty();
+    await expect(timestampButtons(page).first()).toBeVisible();
+    await expect(timestampButtons(page).first()).toHaveText(/^\d{1,2}:\d{2}/);
+    await expect(
+      page.getByText('No transcript available for this episode.')
+    ).toHaveCount(0);
+  });
+
+  // Episode 120 has an explicit markdown transcript AND the feed exposes an RSS
+  // transcript for it — the markdown one must win. Its timestamps come from the
+  // markdown source, so they keep their bracketed form (e.g. "[00:00:00]").
+  test('prefers the explicit markdown transcript, with its own clickable timestamps', async ({
+    page
+  }) => {
+    await page.goto('/120');
+
+    await expect(
+      page.getByRole('heading', { name: 'Episode Transcript' })
+    ).toBeVisible();
+    await expect(page.locator('article.transcript')).not.toBeEmpty();
+    // Bracketed labels prove the markdown transcript rendered, not the RSS one.
+    await expect(timestampButtons(page).first()).toHaveText(/^\[\d{2}:\d{2}/);
+    await expect(
+      page.getByText('No transcript available for this episode.')
+    ).toHaveCount(0);
+  });
+
+  // Clicking a timestamp should load the episode into the audio player. We
+  // assert the player mounts with the episode (a real click is a trusted user
+  // gesture); we don't assert the exact seek position because that depends on
+  // streaming the remote audio, which is flaky in CI. Covers both the RSS
+  // (episode 6) and markdown (episode 120) timestamp paths.
+  for (const { episode, marker } of [
+    { episode: '6', marker: 'DevOps, Arcades and Whatnot' },
+    { episode: '120', marker: 'Tailwind Fandom' }
+  ]) {
+    test(`clicking a timestamp on episode ${episode} loads it into the player`, async ({
+      page
+    }) => {
+      await page.goto(`/${episode}`);
+
+      // The player only exists in the DOM once an episode is playing.
+      await expect(page.locator('.player')).toHaveCount(0);
+
+      await timestampButtons(page).first().click();
+
+      const player = page.locator('.player');
+      await expect(player).toBeVisible();
+      await expect(player).toContainText(marker);
+      await expect(player.locator('audio')).toHaveAttribute('src', /.+\.mp3/);
+    });
+  }
 });

--- a/tests/unit/rehype-transcript-timestamps.test.ts
+++ b/tests/unit/rehype-transcript-timestamps.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import rehypeTranscriptTimestamps from '../../src/lib/rehype-transcript-timestamps.mjs';
+
+type HastNode = {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: Array<HastNode>;
+};
+
+function run(tree: HastNode) {
+  rehypeTranscriptTimestamps()(tree);
+  return tree;
+}
+
+function paragraph(...children: Array<HastNode>): HastNode {
+  return { type: 'root', children: [{ type: 'element', tagName: 'p', children }] };
+}
+
+function text(value: string): HastNode {
+  return { type: 'text', value };
+}
+
+function buttonsIn(tree: HastNode): Array<HastNode> {
+  const found: Array<HastNode> = [];
+  const walk = (node: HastNode) => {
+    if (node.tagName === 'button') found.push(node);
+    node.children?.forEach(walk);
+  };
+  walk(tree);
+  return found;
+}
+
+describe('rehypeTranscriptTimestamps', () => {
+  it('converts an [HH:MM:SS] timestamp into a seek button with the right offset', () => {
+    const tree = run(paragraph(text('[00:01:23] hello')));
+    const [button] = buttonsIn(tree);
+
+    expect(button.tagName).toBe('button');
+    expect(button.properties?.['data-seek']).toBe('83');
+    expect(button.properties?.['aria-label']).toBe('Play from [00:01:23]');
+    // The visible label keeps the original bracketed timestamp.
+    expect(button.children?.[0]?.value).toBe('[00:01:23]');
+  });
+
+  it('converts an [MM:SS] timestamp (no hours) into the right offset', () => {
+    const tree = run(paragraph(text('[04:12] hello')));
+    const [button] = buttonsIn(tree);
+
+    expect(button.properties?.['data-seek']).toBe('252');
+    expect(button.children?.[0]?.value).toBe('[04:12]');
+  });
+
+  it('preserves surrounding text and sibling elements around the timestamp', () => {
+    const tree = run(
+      paragraph(
+        text('[00:00:15] '),
+        { type: 'element', tagName: 'strong', children: [text('Chuck:')] },
+        text(' welcome')
+      )
+    );
+
+    const p = tree.children![0];
+    // button, " ", <strong>, " welcome"
+    expect(p.children?.map((c) => c.tagName ?? c.type)).toEqual([
+      'button',
+      'text',
+      'strong',
+      'text'
+    ]);
+    expect(p.children?.[2]?.children?.[0]?.value).toBe('Chuck:');
+  });
+
+  it('converts every timestamp within a single text node', () => {
+    const tree = run(paragraph(text('[00:00:01] a [00:00:05] b')));
+    const buttons = buttonsIn(tree);
+
+    expect(buttons.map((b) => b.properties?.['data-seek'])).toEqual(['1', '5']);
+  });
+
+  it('leaves text without timestamps untouched', () => {
+    const tree = run(paragraph(text('no timestamps here')));
+
+    expect(buttonsIn(tree)).toHaveLength(0);
+    expect(tree.children![0].children?.[0]?.value).toBe('no timestamps here');
+  });
+});

--- a/tests/unit/rehype-transcript-timestamps.test.ts
+++ b/tests/unit/rehype-transcript-timestamps.test.ts
@@ -80,6 +80,15 @@ describe('rehypeTranscriptTimestamps', () => {
     expect(buttons.map((b) => b.properties?.['data-seek'])).toEqual(['1', '5']);
   });
 
+  it('converts timestamps across sibling text nodes (no regex state leaks between them)', () => {
+    const tree = run(
+      paragraph(text('[00:00:01] first'), text('[00:00:05] second'))
+    );
+    const buttons = buttonsIn(tree);
+
+    expect(buttons.map((b) => b.properties?.['data-seek'])).toEqual(['1', '5']);
+  });
+
   it('leaves text without timestamps untouched', () => {
     const tree = run(paragraph(text('no timestamps here')));
 

--- a/tests/unit/transcript.test.ts
+++ b/tests/unit/transcript.test.ts
@@ -103,7 +103,7 @@ describe('getRssTranscriptParagraphs', () => {
     ]);
   });
 
-  it('strips WebVTT scaffolding for non-JSON transcripts', async () => {
+  it('parses WebVTT cues, preserving the start time so timestamps stay clickable', async () => {
     const vtt = [
       'WEBVTT',
       '',
@@ -121,9 +121,48 @@ describe('getRssTranscriptParagraphs', () => {
       makeEpisode({ transcriptType: 'text/vtt' })
     );
 
+    // Short cues group into one paragraph tagged with the first cue's start.
     expect(paragraphs).toEqual([
-      { text: 'Hello there.' },
-      { text: 'Welcome to the show.' }
+      { start: 4.5, text: 'Hello there. Welcome to the show.' }
+    ]);
+  });
+
+  it('parses SRT cues (comma milliseconds, HH:MM:SS) with start times', async () => {
+    const longCue = 'word '.repeat(140).trim(); // forces a paragraph break
+    const srt = [
+      '1',
+      '00:00:03,000 --> 00:00:30,000',
+      longCue,
+      '',
+      '2',
+      '01:02:03,000 --> 01:02:10,000',
+      'Second cue.'
+    ].join('\n');
+    mockFetch({ body: srt });
+
+    const paragraphs = await getRssTranscriptParagraphs(
+      makeEpisode({ transcriptType: 'application/x-subrip' })
+    );
+
+    expect(paragraphs).toEqual([
+      { start: 3, text: longCue },
+      { start: 3723, text: 'Second cue.' } // 1h 2m 3s
+    ]);
+  });
+
+  it('falls back to plain-text paragraphs when there are no cues', async () => {
+    mockFetch({
+      body: 'First paragraph.\n\nSecond paragraph.',
+      contentType: 'text/plain'
+    });
+
+    const paragraphs = await getRssTranscriptParagraphs(
+      makeEpisode({ transcriptType: 'text/plain' })
+    );
+
+    expect(paragraphs).toEqual([
+      { text: 'First paragraph.' },
+      { text: 'Second paragraph.' }
     ]);
   });
 

--- a/tests/unit/transcript.test.ts
+++ b/tests/unit/transcript.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getRssTranscriptParagraphs,
+  getRssTranscriptText
+} from '../../src/lib/transcript';
+import type { Episode } from '../../src/lib/rss';
+
+// Each test uses a unique transcript URL because the module caches parsed
+// transcripts by URL — reusing a URL would return a previous test's cached
+// result instead of re-fetching.
+let urlCounter = 0;
+function uniqueUrl() {
+  urlCounter += 1;
+  return `https://example.com/transcript-${urlCounter}.json`;
+}
+
+function makeEpisode(overrides: Partial<Episode> = {}): Episode {
+  return {
+    transcriptUrl: uniqueUrl(),
+    transcriptType: 'application/json',
+    ...overrides
+  } as Episode;
+}
+
+function mockFetch(response: {
+  ok?: boolean;
+  body?: string;
+  contentType?: string;
+}) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: response.ok ?? true,
+    text: async () => response.body ?? '',
+    headers: { get: () => response.contentType ?? null }
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getRssTranscriptParagraphs', () => {
+  it('returns null when the episode has no RSS transcript URL', async () => {
+    const fetchMock = mockFetch({ body: '{}' });
+    const episode = makeEpisode({ transcriptUrl: undefined });
+
+    expect(await getRssTranscriptParagraphs(episode)).toBeNull();
+    // No transcript URL means we should never hit the network.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('parses JSON segments into paragraphs tagged with their start time', async () => {
+    mockFetch({
+      body: JSON.stringify({
+        segments: [
+          { start: 4.5, text: 'Hello there.' },
+          { start: 8, text: 'Welcome to the show.' }
+        ]
+      })
+    });
+
+    const paragraphs = await getRssTranscriptParagraphs(makeEpisode());
+
+    // Two short segments stay in a single paragraph, tagged with the first
+    // segment's start time.
+    expect(paragraphs).toEqual([
+      { start: 4.5, text: 'Hello there. Welcome to the show.' }
+    ]);
+  });
+
+  it('breaks into a new paragraph once a segment run gets long', async () => {
+    const longText = 'word '.repeat(140).trim(); // ~700 chars, past the target
+    mockFetch({
+      body: JSON.stringify({
+        segments: [
+          { start: 0, text: longText },
+          { start: 120, text: 'A second paragraph.' }
+        ]
+      })
+    });
+
+    const paragraphs = await getRssTranscriptParagraphs(makeEpisode());
+
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs?.[0]).toEqual({ start: 0, text: longText });
+    expect(paragraphs?.[1]).toEqual({ start: 120, text: 'A second paragraph.' });
+  });
+
+  it('falls back to the plain `text` field (no start times) when there are no segments', async () => {
+    mockFetch({
+      body: JSON.stringify({
+        text: 'First paragraph.\n\nSecond paragraph.'
+      })
+    });
+
+    const paragraphs = await getRssTranscriptParagraphs(makeEpisode());
+
+    expect(paragraphs).toEqual([
+      { text: 'First paragraph.' },
+      { text: 'Second paragraph.' }
+    ]);
+  });
+
+  it('strips WebVTT scaffolding for non-JSON transcripts', async () => {
+    const vtt = [
+      'WEBVTT',
+      '',
+      '1',
+      '00:00:04.500 --> 00:00:08.000',
+      'Hello there.',
+      '',
+      '2',
+      '00:00:08.000 --> 00:00:12.000',
+      'Welcome to the show.'
+    ].join('\n');
+    mockFetch({ body: vtt });
+
+    const paragraphs = await getRssTranscriptParagraphs(
+      makeEpisode({ transcriptType: 'text/vtt' })
+    );
+
+    expect(paragraphs).toEqual([
+      { text: 'Hello there.' },
+      { text: 'Welcome to the show.' }
+    ]);
+  });
+
+  it('uses the response content-type when the feed omits a transcript type', async () => {
+    mockFetch({
+      contentType: 'application/json; charset=utf-8',
+      body: JSON.stringify({ segments: [{ start: 1, text: 'Detected as JSON.' }] })
+    });
+
+    const paragraphs = await getRssTranscriptParagraphs(
+      makeEpisode({ transcriptType: undefined })
+    );
+
+    expect(paragraphs).toEqual([{ start: 1, text: 'Detected as JSON.' }]);
+  });
+
+  it('returns null when the transcript response is not ok', async () => {
+    mockFetch({ ok: false, body: 'Not Found' });
+
+    expect(await getRssTranscriptParagraphs(makeEpisode())).toBeNull();
+  });
+
+  it('returns null when the fetch throws', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('network down'))
+    );
+
+    expect(await getRssTranscriptParagraphs(makeEpisode())).toBeNull();
+  });
+
+  it('returns null when the JSON transcript is malformed', async () => {
+    mockFetch({ body: 'not json at all' });
+
+    expect(await getRssTranscriptParagraphs(makeEpisode())).toBeNull();
+  });
+
+  it('returns null when a JSON transcript has neither segments nor text', async () => {
+    mockFetch({ body: JSON.stringify({ word_count: 0 }) });
+
+    expect(await getRssTranscriptParagraphs(makeEpisode())).toBeNull();
+  });
+
+  it('caches by URL so the same transcript is only fetched once', async () => {
+    const fetchMock = mockFetch({
+      body: JSON.stringify({ segments: [{ start: 0, text: 'Cached.' }] })
+    });
+    const episode = makeEpisode();
+
+    const first = await getRssTranscriptParagraphs(episode);
+    const second = await getRssTranscriptParagraphs(episode);
+
+    expect(first).toEqual(second);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getRssTranscriptText', () => {
+  it('joins paragraphs with blank lines', async () => {
+    mockFetch({
+      body: JSON.stringify({
+        text: 'First paragraph.\n\nSecond paragraph.'
+      })
+    });
+
+    const text = await getRssTranscriptText(makeEpisode());
+
+    expect(text).toBe('First paragraph.\n\nSecond paragraph.');
+  });
+
+  it('returns null when there is no usable transcript', async () => {
+    const episode = makeEpisode({ transcriptUrl: undefined });
+
+    expect(await getRssTranscriptText(episode)).toBeNull();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added podcast RSS transcript fallback when no dedicated transcript is available.
  * Made transcript timestamps clickable in both RSS and markdown transcripts, enabling instant seeking.
  * Improved transcript handling across JSON, WebVTT, SRT, and plain text, with better enclosure selection.
* **Bug Fixes**
  * Improved seek behavior reliability, including restoring playback state when seeking is blocked.
* **Documentation**
  * Updated transcript generation/rendering documentation and dev notes.
* **Tests**
  * Added end-to-end and unit coverage for transcript parsing, caching, timestamp seeking, and playback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->