### PR TITLE
Poll RSS feed for new episodes and trigger rebuild before ATProto publish

### DIFF
--- a/.github/workflows/publish-episodes.yml
+++ b/.github/workflows/publish-episodes.yml
@@ -136,4 +136,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .feed-hash
-          key: feed-hash-${{ needs.gate.outputs.feed-hash }}
+          # Include run id/attempt so re-publishing a previously seen hash
+          # still saves (cache keys are immutable); the prefix restore picks
+          # the most recently created entry.
+          key: feed-hash-${{ needs.gate.outputs.feed-hash }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/publish-episodes.yml
+++ b/.github/workflows/publish-episodes.yml
@@ -1,22 +1,29 @@
 name: Publish Episodes to ATProto
 
 on:
-  # Run after the daily site rebuild to catch new episodes
-  workflow_run:
-    workflows: ["Rebuild Astro Site"]
-    types: [completed]
-  # Allow manual trigger
+  # Poll the RSS feed for new episodes. Offset from the top of the hour —
+  # GitHub delays cron runs scheduled at :00/:30 the most.
+  schedule:
+    - cron: "7,37 * * * *"
+  # Allow manual trigger (skips the feed-changed gate)
   workflow_dispatch:
 
+concurrency:
+  group: publish-episodes
+  cancel-in-progress: false
+
 jobs:
-  # Skip publishing entirely if standard.site/ATProto secrets aren't configured,
-  # so forks without standard.site set up don't fail this workflow.
-  check:
+  # Gate: skip publishing entirely if standard.site/ATProto secrets aren't
+  # configured (so forks without standard.site set up don't fail this
+  # workflow), and skip scheduled runs when the feed hasn't changed since the
+  # last successful publish.
+  gate:
     runs-on: ubuntu-latest
-    # Only run if the triggering workflow succeeded (or manual dispatch)
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       configured: ${{ steps.config.outputs.configured }}
+      changed: ${{ steps.feed.outputs.changed }}
+      feed-hash: ${{ steps.feed.outputs.hash }}
+      rebuild-triggered: ${{ steps.rebuild.outputs.triggered }}
     steps:
       - name: Check ATProto configuration
         id: config
@@ -32,10 +39,64 @@ jobs:
             echo "configured=false" >> "$GITHUB_OUTPUT"
             echo "::notice::standard.site/ATProto secrets not set — skipping episode publishing."
           fi
+      - uses: actions/checkout@v4
+        if: steps.config.outputs.configured == 'true'
+      - name: Restore last published feed hash
+        if: steps.config.outputs.configured == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: .feed-hash
+          key: feed-hash-
+          restore-keys: |
+            feed-hash-
+      - name: Check feed for changes
+        if: steps.config.outputs.configured == 'true'
+        id: feed
+        run: |
+          set -euo pipefail
+          FEED_URL=$(sed -n "s/.*rssFeed: *['\"]\([^'\"]*\)['\"].*/\1/p" starpod.config.ts | head -1)
+          if [ -z "$FEED_URL" ]; then
+            echo "::warning::Could not extract rssFeed from starpod.config.ts — publishing unconditionally."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! FEED_BODY=$(curl -sfL "$FEED_URL"); then
+            echo "::warning::Could not fetch RSS feed — publishing unconditionally."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          HASH=$(printf '%s' "$FEED_BODY" | sha256sum | cut -d' ' -f1)
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          PREV=$(cat .feed-hash 2>/dev/null || true)
+          if [ "$HASH" = "$PREV" ]; then
+            echo "Feed unchanged since last publish."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Feed changed (or no previous hash) — publishing."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      # Kick off the Vercel rebuild as soon as a feed change is detected, so
+      # the site build runs while the publish job is installing dependencies.
+      # The publish script then waits for the new episode pages to be live
+      # before publishing documents that link to them.
+      - name: Trigger site rebuild
+        if: steps.config.outputs.configured == 'true' && steps.feed.outputs.changed == 'true'
+        id: rebuild
+        env:
+          REBUILD_WEBHOOK: ${{ secrets.REBUILD_WEBHOOK }}
+        run: |
+          if [ -n "$REBUILD_WEBHOOK" ]; then
+            curl -sf -X POST "$REBUILD_WEBHOOK" > /dev/null
+            echo "triggered=true" >> "$GITHUB_OUTPUT"
+            echo "Triggered site rebuild."
+          else
+            echo "triggered=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::REBUILD_WEBHOOK not set — publishing without waiting for a site rebuild."
+          fi
 
   publish:
-    needs: check
-    if: ${{ needs.check.outputs.configured == 'true' }}
+    needs: gate
+    if: ${{ needs.gate.outputs.configured == 'true' && (github.event_name == 'workflow_dispatch' || needs.gate.outputs.changed == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,3 +125,15 @@ jobs:
           ATPROTO_APP_PASSWORD: ${{ secrets.ATPROTO_APP_PASSWORD }}
           STANDARD_SITE_URL: ${{ secrets.STANDARD_SITE_URL }}
           STANDARD_SITE_PUBLICATION_RKEY: ${{ secrets.STANDARD_SITE_PUBLICATION_RKEY }}
+          WAIT_FOR_SITE: ${{ needs.gate.outputs.rebuild-triggered }}
+      # Record the feed hash only after a successful publish, so a failed run
+      # is retried on the next scheduled poll.
+      - name: Record published feed hash
+        if: ${{ needs.gate.outputs.feed-hash != '' }}
+        run: printf '%s' "${{ needs.gate.outputs.feed-hash }}" > .feed-hash
+      - name: Save feed hash
+        if: ${{ needs.gate.outputs.feed-hash != '' }}
+        uses: actions/cache/save@v4
+        with:
+          path: .feed-hash
+          key: feed-hash-${{ needs.gate.outputs.feed-hash }}

--- a/README.md
+++ b/README.md
@@ -167,8 +167,10 @@ variables → Actions → New repository secret**:
 
 Episodes are published to ATProto as individual documents automatically:
 
-- **Automatic** — The `Publish Episodes to ATProto` workflow runs after each
-  daily site rebuild and publishes any new episodes
+- **Automatic** — The `Publish Episodes to ATProto` workflow polls the RSS
+  feed every 30 minutes; when it finds new episodes it triggers a site rebuild
+  (via the `REBUILD_WEBHOOK` secret), waits for the new episode pages to be
+  live, and then publishes the episodes
 - **Manual** — Trigger the workflow manually from the Actions tab
 - **Backfill** — Use the `Backfill Episodes to ATProto` workflow (Actions tab →
   Run workflow → type "backfill") to publish all existing episodes

--- a/scripts/publish-episodes.ts
+++ b/scripts/publish-episodes.ts
@@ -164,6 +164,7 @@ async function main() {
 
   let published = 0;
   let skipped = 0;
+  let failed = 0;
 
   for (const episode of episodes) {
     const slug = dasherize(episode.title);
@@ -205,13 +206,20 @@ async function main() {
         skipped++;
       } else {
         console.error(`  ❌ ${episode.title}: ${message}`);
+        failed++;
       }
     }
   }
 
   console.log(
-    `\n🎉 Done! Published: ${published}, Skipped: ${skipped}, Total episodes: ${episodes.length}`
+    `\n🎉 Done! Published: ${published}, Skipped: ${skipped}, Failed: ${failed}, Total episodes: ${episodes.length}`
   );
+
+  // Exit nonzero so the workflow doesn't record the feed hash and the failed
+  // episodes are retried on the next scheduled run.
+  if (failed > 0) {
+    throw new Error(`${failed} episode(s) failed to publish.`);
+  }
 }
 
 main().catch((err) => {

--- a/scripts/publish-episodes.ts
+++ b/scripts/publish-episodes.ts
@@ -144,16 +144,20 @@ async function main() {
     cursor = response.data.cursor;
   } while (cursor);
 
-  // All new episode pages come from the same rebuild, so once the first new
-  // page is live the rest are too.
+  // Vercel deploys are atomic, so new pages go live together — but wait on
+  // every unpublished page so publishing can't outrun the rebuild regardless
+  // of feed ordering or previously failed publishes.
   if (WAIT_FOR_SITE && !BACKFILL) {
-    const firstNew = episodes.find(
-      (episode) => !existingPaths.has(`/${dasherize(episode.title)}`)
-    );
-    if (firstNew) {
-      const pageUrl = `${siteUrl.replace(/\/$/, '')}/${dasherize(firstNew.title)}`;
-      console.log(`⏳ Waiting for rebuilt site to serve ${pageUrl}...`);
-      await waitForPage(pageUrl);
+    const pendingUrls = episodes
+      .filter((episode) => !existingPaths.has(`/${dasherize(episode.title)}`))
+      .map(
+        (episode) => `${siteUrl.replace(/\/$/, '')}/${dasherize(episode.title)}`
+      );
+    if (pendingUrls.length > 0) {
+      console.log(
+        `⏳ Waiting for rebuilt site to serve ${pendingUrls.length} new episode page(s)...`
+      );
+      await Promise.all(pendingUrls.map((url) => waitForPage(url)));
       console.log('✅ Site rebuild is live.');
     }
   }

--- a/scripts/publish-episodes.ts
+++ b/scripts/publish-episodes.ts
@@ -29,6 +29,38 @@ import starpodConfig from '../starpod.config';
 import { dasherize } from '../src/utils/dasherize';
 
 const BACKFILL = process.argv.includes('--backfill');
+// Set by the GitHub workflow when it has just triggered a site rebuild:
+// published documents link to episode pages, so wait for the rebuilt site to
+// serve them before publishing.
+const WAIT_FOR_SITE = process.env.WAIT_FOR_SITE === 'true';
+
+const PAGE_WAIT_TIMEOUT_MS = 10 * 60 * 1000;
+const PAGE_WAIT_INTERVAL_MS = 15 * 1000;
+
+async function waitForPage(url: string) {
+  const deadline = Date.now() + PAGE_WAIT_TIMEOUT_MS;
+
+  for (;;) {
+    try {
+      const response = await fetch(url, { method: 'HEAD' });
+      if (response.ok) {
+        return;
+      }
+      console.log(`  ⏳ ${url} → ${response.status}, waiting for rebuild...`);
+    } catch (err) {
+      console.log(`  ⏳ ${url} unreachable, waiting for rebuild... (${err})`);
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for ${url} — site rebuild may have failed. ` +
+          'Episodes will be retried on the next scheduled run.'
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, PAGE_WAIT_INTERVAL_MS));
+  }
+}
 
 const FeedSchema = object({
   items: array(
@@ -111,6 +143,20 @@ async function main() {
 
     cursor = response.data.cursor;
   } while (cursor);
+
+  // All new episode pages come from the same rebuild, so once the first new
+  // page is live the rest are too.
+  if (WAIT_FOR_SITE && !BACKFILL) {
+    const firstNew = episodes.find(
+      (episode) => !existingPaths.has(`/${dasherize(episode.title)}`)
+    );
+    if (firstNew) {
+      const pageUrl = `${siteUrl.replace(/\/$/, '')}/${dasherize(firstNew.title)}`;
+      console.log(`⏳ Waiting for rebuilt site to serve ${pageUrl}...`);
+      await waitForPage(pageUrl);
+      console.log('✅ Site rebuild is live.');
+    }
+  }
 
   let published = 0;
   let skipped = 0;


### PR DESCRIPTION
## Why

Publishing episodes to standard.site/ATProto was brittle: it chained off the daily rebuild cron via `workflow_run` (which only proved the webhook curl succeeded, not the build), ran at most once a day, and could publish documents linking to episode pages the site hadn't built yet.

## What

**Feed polling replaces the workflow_run chain.** `publish-episodes.yml` now runs on its own schedule (`7,37 * * * *` — every 30 min, offset from top-of-hour where GitHub cron drift is worst). A cheap `gate` job fetches the RSS feed, hashes the body, and compares against the hash from the last successful publish (persisted with `actions/cache`); unchanged feed → the expensive publish job is skipped entirely.

**Rebuild is now event-driven for episodes.** When the gate detects a feed change it POSTs the `REBUILD_WEBHOOK` immediately, so the Vercel build runs while the publish job installs dependencies. The publish script then waits (HEAD polling, 15s interval, 10 min budget) for the first new episode page to return 200 before publishing — ATProto documents can never link to a 404. The site's episode routes use the same `dasherize(title)` slug the script computes, verified against the live feed + whiskey.fm.

**Failure modes are all retry-safe.** The feed hash is saved only after a successful publish, so a failed fetch, failed rebuild, or timed-out wait just retries on the next poll; the publish script was already idempotent (dedupes against existing ATProto records). Forks without `REBUILD_WEBHOOK` or the ATProto secrets skip the respective steps gracefully. Manual `workflow_dispatch` bypasses the feed-changed gate.

The daily `rebuild.yml` cron is left in place — it's still the only thing picking up guest/sponsor DB changes.

## Notes

- New-episode latency drops from up to 24h to ~30–60 min.
- GitHub disables scheduled workflows after ~60 days without repo activity; Actions emails a warning and one click re-enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Episode publishing now checks the RSS feed every 30 minutes.
  * New episodes can automatically trigger a website rebuild before publishing.
  * Publishing waits for the updated episode page to become available.
  * Manual publishing remains supported.

* **Bug Fixes**
  * Prevented unnecessary publishing when the RSS feed has not changed.
  * Added retry and timeout handling while waiting for refreshed pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->