### PR TITLE
Expand contact page trust content and enrich JSON-LD identity

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,6 +37,16 @@ const { imageUrl, title } = Astro.props;
 const canonicalURL =
   Astro.props.canonicalURL ?? new URL(Astro.url.pathname, Astro.site);
 const description = Astro.props.description ?? starpodConfig.description;
+
+// The show's profiles elsewhere, so agents can connect this site to the same
+// entity on other platforms (JSON-LD sameAs).
+const sameAs = [
+  starpodConfig.platforms.apple,
+  starpodConfig.platforms.spotify,
+  starpodConfig.platforms.youtube,
+  starpodConfig.platforms.overcast,
+  starpodConfig.platforms.pocketCasts
+].filter((url): url is string => Boolean(url));
 ---
 
 <!doctype html>
@@ -108,15 +118,22 @@ const description = Astro.props.description ?? starpodConfig.description;
         description: show.description,
         url: canonicalURL.toString(),
         webFeed: starpodConfig.rssFeed,
+        sameAs,
         author: {
           '@type': 'Organization',
           name: show.title,
-          url: canonicalURL.origin
+          description: starpodConfig.description,
+          url: canonicalURL.origin,
+          logo: show.image,
+          sameAs
         },
         publisher: {
           '@type': 'Organization',
           name: show.title,
-          url: canonicalURL.origin
+          description: starpodConfig.description,
+          url: canonicalURL.origin,
+          logo: show.image,
+          sameAs
         },
         image: show.image
       }}

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,6 +1,18 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import ContactForm from '../components/ContactForm';
+import { getShowInfo } from '../lib/rss';
+import starpodConfig from 'starpod.config';
+
+const show = await getShowInfo();
+
+const platformLinks = [
+  { name: 'Apple Podcasts', url: starpodConfig.platforms.apple },
+  { name: 'Spotify', url: starpodConfig.platforms.spotify },
+  { name: 'YouTube', url: starpodConfig.platforms.youtube },
+  { name: 'Overcast', url: starpodConfig.platforms.overcast },
+  { name: 'Pocket Casts', url: starpodConfig.platforms.pocketCasts }
+].filter((platform) => platform.url);
 ---
 
 <Layout title="Contact">
@@ -12,10 +24,93 @@ import ContactForm from '../components/ContactForm';
     </h1>
 
     <p class="mb-8">
-      Have a question for us or a topic you would like us to cover on the show?
-      Reach out here and we'll be in touch soon!
+      Have a question for us, feedback on an episode, or a topic you would like
+      us to cover on {show.title}? Maybe a guest you want to hear from, or just
+      something you want to say? Fill out the form below and your message goes
+      straight to the hosts — we read every one and we'll be in touch soon!
     </p>
 
     <ContactForm client:load />
+
+    <div class="mt-12 pb-16">
+      <h2
+        class="text-light-text-heading mb-4 text-xl font-bold dark:text-white"
+      >
+        Reach the hosts directly
+      </h2>
+
+      <ul class="mb-8 flex flex-col gap-2">
+        {
+          starpodConfig.hosts.map((host) => (
+            <li>
+              <span class="font-bold">{host.name}</span>
+              {host.twitter && (
+                <>
+                  {' — '}
+                  <a
+                    class="underline hover:no-underline"
+                    href={host.twitter}
+                    rel="noopener noreferrer"
+                  >
+                    Twitter
+                  </a>
+                </>
+              )}
+              {host.github && (
+                <>
+                  {' · '}
+                  <a
+                    class="underline hover:no-underline"
+                    href={host.github}
+                    rel="noopener noreferrer"
+                  >
+                    GitHub
+                  </a>
+                </>
+              )}
+              {host.website && (
+                <>
+                  {' · '}
+                  <a
+                    class="underline hover:no-underline"
+                    href={host.website}
+                    rel="noopener noreferrer"
+                  >
+                    Website
+                  </a>
+                </>
+              )}
+            </li>
+          ))
+        }
+      </ul>
+
+      {
+        platformLinks.length > 0 && (
+          <>
+            <h2 class="text-light-text-heading mb-4 text-xl font-bold dark:text-white">
+              Follow the show
+            </h2>
+            <p class="mb-4">
+              The best way to support {show.title} is to subscribe, leave a
+              review, and share episodes with your friends. You can find us on:
+            </p>
+            <ul class="flex flex-wrap gap-x-6 gap-y-2">
+              {platformLinks.map((platform) => (
+                <li>
+                  <a
+                    class="underline hover:no-underline"
+                    href={platform.url}
+                    rel="noopener noreferrer"
+                  >
+                    {platform.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </>
+        )
+      }
+    </div>
   </div>
 </Layout>

--- a/tests/e2e/trust-identity.spec.ts
+++ b/tests/e2e/trust-identity.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('JSON-LD identity', () => {
+  test('homepage JSON-LD carries full Organization identity', async ({
+    page
+  }) => {
+    await page.goto('/');
+
+    const jsonLd = await page
+      .locator('script[type="application/ld+json"]')
+      .first()
+      .textContent();
+    const schema = JSON.parse(jsonLd!);
+
+    expect(schema['@type']).toBe('PodcastSeries');
+    expect(schema.publisher['@type']).toBe('Organization');
+    expect(schema.publisher.url).toBeTruthy();
+    expect(schema.publisher.logo).toBeTruthy();
+    expect(schema.publisher.sameAs.length).toBeGreaterThan(0);
+  });
+});
+
+test.describe('contact trust page', () => {
+  test('has substantive contact content beyond the form', async ({ page }) => {
+    await page.goto('/contact');
+
+    await expect(
+      page.getByRole('heading', { name: 'Get in touch' })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Reach the hosts directly' })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Follow the show' })
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Part of the agent-readiness work (Is Agentic audit): trust-anchor pages and machine-parsable identity are what agents check before recommending a site.

- **Contact page**: adds config-driven content beyond the bare form — direct host links (Twitter/GitHub/website) and platform links, pushing visible content well past the 500-character trust threshold. Form behavior unchanged.
- **JSON-LD** (`Layout.astro`): the `PodcastSeries` and its `author`/`publisher` Organization entities now carry `url`, `description`, `logo`, and `sameAs` (all configured platform profiles), connecting the site to the same entity elsewhere

## Test plan
- E2E: `tests/e2e/trust-identity.spec.ts` parses the homepage JSON-LD (publisher url/logo/sameAs) and verifies the contact page sections render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
