### PR TITLE
Agent-friendly 404s with markdown and JSON bodies

### DIFF
--- a/src/components/NotFoundContent.astro
+++ b/src/components/NotFoundContent.astro
@@ -1,0 +1,42 @@
+---
+import FourZeroFourIllustration from './illustrations/404Illustration.astro';
+---
+
+<div
+  class="relative z-10 flex flex-col items-center justify-center px-8 lg:px-18"
+>
+  <FourZeroFourIllustration />
+
+  <div class="mt-12 flex justify-center">
+    <button class="btn" onclick="history.back()">
+      <span
+        class="text-light-text-heading rounded-full px-10 py-3 text-center text-sm dark:text-white"
+      >
+        Go back
+      </span>
+    </button>
+  </div>
+
+  <nav class="mt-10 pb-16 text-center text-sm" aria-label="Helpful links">
+    <p class="mb-3">Looking for something? Try one of these:</p>
+    <ul class="flex flex-wrap justify-center gap-x-6 gap-y-2">
+      <li>
+        <a class="underline hover:no-underline" href="/">All episodes</a>
+      </li>
+      <li>
+        <a class="underline hover:no-underline" href="/about">About</a>
+      </li>
+      <li>
+        <a class="underline hover:no-underline" href="/contact">Contact</a>
+      </li>
+      <li>
+        <a class="underline hover:no-underline" href="/llms.txt">llms.txt</a>
+      </li>
+      <li>
+        <a class="underline hover:no-underline" href="/sitemap-index.xml">
+          Sitemap
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Structured JSON error responses for API routes. Agents can't parse HTML
+ * error pages, so every API error carries a stable code, a human-readable
+ * message, and a hint for resolving it.
+ */
+export function jsonError(
+  status: number,
+  code: string,
+  message: string,
+  hint?: string,
+  headers?: Record<string, string>
+): Response {
+  return new Response(
+    JSON.stringify({
+      message,
+      error: { code, message, ...(hint ? { hint } : {}) }
+    }),
+    {
+      status,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        ...headers
+      }
+    }
+  );
+}

--- a/src/lib/not-found.ts
+++ b/src/lib/not-found.ts
@@ -1,0 +1,26 @@
+import type { Show } from './rss';
+
+/**
+ * Generate a markdown 404 body pointing agents at recovery entry points, per
+ * agent-friendly 404 guidance: never a bare error, always where to look next.
+ */
+export function generateNotFoundMarkdown(
+  pathname: string,
+  show: Show,
+  siteUrl?: URL
+): string {
+  const baseUrl = siteUrl?.origin || '';
+
+  let markdown = `# 404 - Page Not Found\n\n`;
+  markdown += `\`${pathname}\` does not exist on ${show.title}.\n\n`;
+  markdown += `## Where To Look Next\n\n`;
+  markdown += `- [Homepage](${baseUrl}/index.html.md): Show overview and latest episodes\n`;
+  markdown += `- [Episodes Index](${baseUrl}/episodes-index.html.md): Every episode with links\n`;
+  markdown += `- [llms.txt](${baseUrl}/llms.txt): Structured overview of all resources\n`;
+  markdown += `- [Sitemap](${baseUrl}/sitemap-index.xml): Every page on the site\n`;
+  markdown += `- [OpenAPI Specification](${baseUrl}/openapi.json): JSON API endpoints\n\n`;
+  markdown += `Episode pages live at \`/{episode-slug}\` (or \`/{episode-number}\`), `;
+  markdown += `with markdown versions at \`/{episode-slug}.html.md\`.\n`;
+
+  return markdown;
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,22 +1,8 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import FourZeroFourIllustration from '../components/illustrations/404Illustration.astro';
+import NotFoundContent from '../components/NotFoundContent.astro';
 ---
 
 <Layout title="404 - Not found">
-  <div
-    class="relative z-10 flex flex-col items-center justify-center px-8 lg:px-18"
-  >
-    <FourZeroFourIllustration />
-
-    <div class="mt-12 flex justify-center pb-16">
-      <button class="btn" onclick="history.back()">
-        <span
-          class="text-light-text-heading rounded-full px-10 py-3 text-center text-sm dark:text-white"
-        >
-          Go back
-        </span>
-      </button>
-    </div>
-  </div>
+  <NotFoundContent />
 </Layout>

--- a/src/pages/[...notFound].astro
+++ b/src/pages/[...notFound].astro
@@ -1,0 +1,46 @@
+---
+import Layout from '../layouts/Layout.astro';
+import NotFoundContent from '../components/NotFoundContent.astro';
+import { jsonError } from '../lib/api-errors';
+import { generateNotFoundMarkdown } from '../lib/not-found';
+import { getShowInfo } from '../lib/rss';
+
+// Rendered on demand so nonexistent paths return a real HTTP 404 with a body
+// agents can recover from: JSON for API paths, markdown for markdown-accepting
+// agents, and the regular 404 page for browsers.
+export const prerender = false;
+
+const pathname = Astro.url.pathname;
+
+if (pathname.startsWith('/api/')) {
+  return jsonError(
+    404,
+    'not_found',
+    `No API endpoint exists at ${pathname}`,
+    'See /openapi.json for the available endpoints.'
+  );
+}
+
+const accept = Astro.request.headers.get('accept') ?? '';
+
+if (accept.includes('text/markdown')) {
+  const show = await getShowInfo();
+  const markdown = generateNotFoundMarkdown(pathname, show, Astro.site);
+
+  return new Response(markdown, {
+    status: 404,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      Vary: 'Accept'
+    }
+  });
+}
+
+Astro.response.status = 404;
+Astro.response.statusText = 'Not Found';
+Astro.response.headers.set('Vary', 'Accept');
+---
+
+<Layout title="404 - Not found">
+  <NotFoundContent />
+</Layout>

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,61 +1,116 @@
 import type { APIRoute } from 'astro';
 
+import { jsonError } from '../../lib/api-errors';
+
 export const prerender = false;
 
 export const POST: APIRoute = async ({ request }) => {
-  const data = await request.formData();
+  let data: FormData;
+  try {
+    data = await request.formData();
+  } catch {
+    return jsonError(
+      400,
+      'invalid_body',
+      'Request body could not be parsed as form data',
+      'Send a multipart/form-data or application/x-www-form-urlencoded body with name, email, and message fields.'
+    );
+  }
+
   const name = data.get('name');
   const email = data.get('email');
   const message = data.get('message');
 
   // Validate the data - you'll probably want to do more than this
   if (!name || !email || !message) {
-    return new Response(
-      JSON.stringify({
-        message: 'Missing required fields'
-      }),
-      { status: 400 }
+    const missing = [
+      !name && 'name',
+      !email && 'email',
+      !message && 'message'
+    ].filter(Boolean);
+    return jsonError(
+      400,
+      'missing_fields',
+      `Missing required fields: ${missing.join(', ')}`,
+      'Provide name, email, and message form fields.'
     );
   }
 
-  await fetch(import.meta.env.DISCORD_WEBHOOK, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      embeds: [
-        {
-          title: 'New Contact Form Submission',
-          color: 0x5865f2,
-          fields: [
-            {
-              name: 'Name',
-              value: String(name),
-              inline: true
-            },
-            {
-              name: 'Email',
-              value: String(email),
-              inline: true
-            },
-            {
-              name: 'Message',
-              value: String(message),
-              inline: false
-            }
-          ],
-          timestamp: new Date().toISOString()
-        }
-      ]
-    })
-  });
+  if (!import.meta.env.DISCORD_WEBHOOK) {
+    return jsonError(
+      500,
+      'not_configured',
+      'The contact form is not configured on this deployment',
+      'Set the DISCORD_WEBHOOK environment variable, or reach the hosts via the links on /contact.'
+    );
+  }
+
+  try {
+    const webhookResponse = await fetch(import.meta.env.DISCORD_WEBHOOK, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        embeds: [
+          {
+            title: 'New Contact Form Submission',
+            color: 0x5865f2,
+            fields: [
+              {
+                name: 'Name',
+                value: String(name),
+                inline: true
+              },
+              {
+                name: 'Email',
+                value: String(email),
+                inline: true
+              },
+              {
+                name: 'Message',
+                value: String(message),
+                inline: false
+              }
+            ],
+            timestamp: new Date().toISOString()
+          }
+        ]
+      })
+    });
+
+    if (!webhookResponse.ok) {
+      throw new Error(`Webhook responded with ${webhookResponse.status}`);
+    }
+  } catch {
+    return jsonError(
+      502,
+      'delivery_failed',
+      'Your message could not be delivered',
+      'Try again in a few minutes, or reach the hosts via the links on /contact.'
+    );
+  }
 
   // Do something with the data, then return a success response
   return new Response(
     JSON.stringify({
       message: `Thanks for contacting us! We'll be in touch soon.`
     }),
-    { status: 200 }
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' }
+    }
+  );
+};
+
+// Any other method on this endpoint gets a structured JSON 405, not an HTML
+// error page.
+export const ALL: APIRoute = () => {
+  return jsonError(
+    405,
+    'method_not_allowed',
+    'Only POST is supported on this endpoint',
+    'Send a POST request with name, email, and message form fields.',
+    { Allow: 'POST' }
   );
 };

--- a/tests/e2e/api-errors.spec.ts
+++ b/tests/e2e/api-errors.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('contact API errors', () => {
+  test('missing fields return a structured JSON 400', async ({
+    baseURL,
+    request
+  }) => {
+    // Astro's CSRF protection rejects form POSTs without a matching Origin,
+    // which browsers always send.
+    const response = await request.post('/api/contact', {
+      headers: { Origin: baseURL! },
+      multipart: { name: 'Only Name' }
+    });
+
+    expect(response.status()).toBe(400);
+    expect(response.headers()['content-type']).toContain('application/json');
+
+    const body = await response.json();
+    expect(body.error.code).toBe('missing_fields');
+    expect(body.error.hint).toBeTruthy();
+  });
+
+  test('non-POST methods return a structured JSON 405', async ({
+    request
+  }) => {
+    const response = await request.get('/api/contact');
+
+    expect(response.status()).toBe(405);
+    const body = await response.json();
+    expect(body.error.code).toBe('method_not_allowed');
+  });
+});

--- a/tests/e2e/not-found.spec.ts
+++ b/tests/e2e/not-found.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('agent-friendly 404s', () => {
+  test('nonexistent paths return a real 404 with the styled page', async ({
+    page
+  }) => {
+    const response = await page.goto('/this-page-does-not-exist');
+    expect(response?.status()).toBe(404);
+    await expect(
+      page.getByRole('link', { name: 'All episodes' })
+    ).toBeVisible();
+  });
+
+  test('markdown-accepting agents get a markdown 404 body', async ({
+    request
+  }) => {
+    const response = await request.get('/this-page-does-not-exist', {
+      headers: { Accept: 'text/markdown' }
+    });
+
+    expect(response.status()).toBe(404);
+    expect(response.headers()['content-type']).toContain('text/markdown');
+    expect(response.headers()['vary']).toContain('Accept');
+
+    const body = await response.text();
+    expect(body).toContain('## Where To Look Next');
+    expect(body).toContain('/llms.txt');
+    expect(body).toContain('/episodes-index.html.md');
+  });
+
+  test('unknown API paths return a structured JSON 404', async ({
+    request
+  }) => {
+    const response = await request.get('/api/this-endpoint-does-not-exist');
+
+    expect(response.status()).toBe(404);
+    expect(response.headers()['content-type']).toContain('application/json');
+
+    const body = await response.json();
+    expect(body.error.code).toBe('not_found');
+    expect(body.error.hint).toContain('/openapi.json');
+  });
+});

--- a/tests/unit/contact-api.test.ts
+++ b/tests/unit/contact-api.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ALL, POST } from '../../src/pages/api/contact';
+
+type ApiContext = Parameters<typeof POST>[0];
+
+function postContext(body: FormData | string): ApiContext {
+  const request = new Request('http://localhost/api/contact', {
+    method: 'POST',
+    body
+  });
+  return { request } as ApiContext;
+}
+
+function validForm(): FormData {
+  const form = new FormData();
+  form.set('name', 'Test Person');
+  form.set('email', 'test@example.com');
+  form.set('message', 'Hello!');
+  return form;
+}
+
+describe('contact API', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns structured JSON 400 when fields are missing', async () => {
+    const form = new FormData();
+    form.set('name', 'Only Name');
+
+    const response = await POST(postContext(form));
+    expect(response.status).toBe(400);
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+
+    const body = await response.json();
+    expect(body.error.code).toBe('missing_fields');
+    expect(body.error.message).toContain('email');
+    expect(body.error.message).toContain('message');
+    expect(body.error.hint).toBeTruthy();
+  });
+
+  it('returns structured JSON 500 when the webhook is not configured', async () => {
+    const response = await POST(postContext(validForm()));
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error.code).toBe('not_configured');
+  });
+
+  it('returns structured JSON 502 when delivery fails', async () => {
+    vi.stubEnv('DISCORD_WEBHOOK', 'https://discord.example.com/webhook');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('nope', { status: 500 }))
+    );
+
+    const response = await POST(postContext(validForm()));
+
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.error.code).toBe('delivery_failed');
+    expect(body.error.hint).toBeTruthy();
+  });
+
+  it('returns JSON success when delivery works', async () => {
+    vi.stubEnv('DISCORD_WEBHOOK', 'https://discord.example.com/webhook');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await POST(postContext(validForm()));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+    const body = await response.json();
+    expect(body.message).toContain('Thanks');
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns structured JSON 405 with Allow header for other methods', async () => {
+    const response = await ALL({
+      request: new Request('http://localhost/api/contact', { method: 'GET' })
+    } as ApiContext);
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('Allow')).toBe('POST');
+    const body = await response.json();
+    expect(body.error.code).toBe('method_not_allowed');
+  });
+});

--- a/tests/unit/not-found.test.ts
+++ b/tests/unit/not-found.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateNotFoundMarkdown } from '../../src/lib/not-found';
+import type { Show } from '../../src/lib/rss';
+
+describe('generateNotFoundMarkdown', () => {
+  const mockShow: Show = {
+    title: 'Test Podcast',
+    description: 'A test podcast',
+    image: 'https://example.com/image.jpg',
+    link: 'https://example.com'
+  };
+
+  it('names the missing path and links recovery entry points', () => {
+    const siteUrl = new URL('https://podcast.example.com');
+    const result = generateNotFoundMarkdown('/missing-page', mockShow, siteUrl);
+
+    expect(result).toContain('# 404');
+    expect(result).toContain('`/missing-page`');
+    expect(result).toContain('## Where To Look Next');
+    expect(result).toContain('https://podcast.example.com/llms.txt');
+    expect(result).toContain(
+      'https://podcast.example.com/episodes-index.html.md'
+    );
+    expect(result).toContain('https://podcast.example.com/sitemap-index.xml');
+    expect(result).toContain('https://podcast.example.com/openapi.json');
+  });
+});


### PR DESCRIPTION
Part of the agent-readiness work (Is Agentic audit). Stacked on #50 (uses its `jsonError` helper) — merge that first; GitHub will retarget this to `main` automatically.

Nonexistent paths already returned real 404 status codes, but the body was the styled HTML page, which agents can't recover from. This adds a `[...notFound].astro` on-demand catch-all (`prerender = false`) so misses return a body matched to the caller:

- `/api/*` paths → structured JSON 404 pointing at `/openapi.json`
- `Accept: text/markdown` clients → short markdown body with "Where To Look Next" links (homepage markdown, episodes index, llms.txt, sitemap, OpenAPI spec)
- Browsers → the same styled 404 page as before, now with a modest recovery-links row (also kept in the static `404.astro` fallback via a shared `NotFoundContent.astro`)

Note the tradeoff: a 404 on Vercel is now a serverless invocation instead of a free static file.

## Test plan
- Unit: `tests/unit/not-found.test.ts` for the markdown body generator
- E2E: `tests/e2e/not-found.spec.ts` covers all three variants (status, content type, `Vary: Accept`, recovery links) in all three browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
