### PR TITLE
Emit the site.standard.publication link tag on every page

### DIFF
--- a/packages/starpod/src/layouts/Layout.astro
+++ b/packages/starpod/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import { ClientRouter } from 'astro:transitions';
 import { Schema } from 'astro-seo-schema';
 
 import SpeedInsights from '@vercel/speed-insights/astro';
+import { getPublicationAtUri } from '@bryanguffey/astro-standard-site';
 
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import Dots from 'virtual:starpod/components/Dots';
@@ -40,6 +41,22 @@ const { imageUrl, title } = Astro.props;
 const canonicalURL =
   Astro.props.canonicalURL ?? new URL(Astro.url.pathname, Astro.site);
 const description = Astro.props.description ?? starpodConfig.description;
+
+// standard.site publication discovery hint. Bluesky's AppView needs this
+// `<link rel="site.standard.publication">` tag on every page (home + episodes)
+// to render shared links as a verified publication. On episode pages it sits
+// alongside the per-page `<link rel="site.standard.document">` tag. Only
+// emitted when the site has configured standard.site publishing.
+const standardSiteDid = import.meta.env.STANDARD_SITE_DID;
+const standardSitePublicationRkey = import.meta.env
+  .STANDARD_SITE_PUBLICATION_RKEY;
+const publicationLinkTag =
+  standardSiteDid && standardSitePublicationRkey
+    ? `<link rel="site.standard.publication" href="${getPublicationAtUri(
+        standardSiteDid,
+        standardSitePublicationRkey
+      )}">`
+    : null;
 ---
 
 <!doctype html>
@@ -124,6 +141,8 @@ const description = Astro.props.description ?? starpodConfig.description;
         image: show.image
       }}
     />
+
+    {publicationLinkTag && <Fragment set:html={publicationLinkTag} />}
 
     <slot name="head" />
     <ClientRouter />


### PR DESCRIPTION
## What

Adds the site-wide `<link rel="site.standard.publication">` discovery hint to the package Layout, emitted when `STANDARD_SITE_DID` and `STANDARD_SITE_PUBLICATION_RKEY` are set (and omitted entirely otherwise).

## Why

Bluesky's AppView needs this tag on **every** page — home and episode pages alike — to render shared links as a verified publication. The package currently only emits the per-episode `site.standard.document` tag in `[episode].astro` and the `/.well-known/site.standard.publication` endpoint.

whiskey.fm carried this fix in its fork (www-starpod `846665e`); converting that site to consume `starpod` from npm dropped the tag, since the Layout has no override hook. This upstreams it.

## Verification

Built the reference site with test values set:

```html
<link rel="site.standard.publication" href="at://did:plc:test123/site.standard.publication/testrkey">
```

renders in the head of `/`, `/about`, and episode pages; a build without the env vars emits nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for linking configured standard-site publications in the page metadata.
  * The link is included automatically when the required publication settings are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->