### PR TITLE
Emit site.standard.publication link tag from the package Layout

### DIFF
--- a/packages/starpod/src/layouts/Layout.astro
+++ b/packages/starpod/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import { ClientRouter } from 'astro:transitions';
 import { Schema } from 'astro-seo-schema';
 
 import SpeedInsights from '@vercel/speed-insights/astro';
+import { getPublicationAtUri } from '@bryanguffey/astro-standard-site';
 
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import Dots from 'virtual:starpod/components/Dots';
@@ -40,6 +41,21 @@ const { imageUrl, title } = Astro.props;
 const canonicalURL =
   Astro.props.canonicalURL ?? new URL(Astro.url.pathname, Astro.site);
 const description = Astro.props.description ?? starpodConfig.description;
+
+// standard.site publication discovery hint. Bluesky's AppView needs this
+// `<link rel="site.standard.publication">` tag on every page (home + episodes)
+// to render shared links as a verified publication. On episode pages it sits
+// alongside the per-page `<link rel="site.standard.document">` tag.
+const standardSiteDid = import.meta.env.STANDARD_SITE_DID;
+const standardSitePublicationRkey = import.meta.env
+  .STANDARD_SITE_PUBLICATION_RKEY;
+const publicationLinkTag =
+  standardSiteDid && standardSitePublicationRkey
+    ? `<link rel="site.standard.publication" href="${getPublicationAtUri(
+        standardSiteDid,
+        standardSitePublicationRkey
+      )}">`
+    : null;
 ---
 
 <!doctype html>
@@ -124,6 +140,8 @@ const description = Astro.props.description ?? starpodConfig.description;
         image: show.image
       }}
     />
+
+    {publicationLinkTag && <Fragment set:html={publicationLinkTag} />}
 
     <slot name="head" />
     <ClientRouter />


### PR DESCRIPTION
The forked Layout in www-starpod emitted a site-wide `<link rel="site.standard.publication">` tag on every page (home + episode pages) when `STANDARD_SITE_DID` and `STANDARD_SITE_PUBLICATION_RKEY` are set. Bluesky's AppView needs this tag to render shared links as a verified publication.

The package Layout lost this tag when www-starpod converted to consuming starpod from npm — the package only emitted the per-episode `site.standard.document` tag in `[episode].astro` and the `/.well-known/site.standard.publication` endpoint.

This ports the fork's implementation (www-starpod `846665e`) into `packages/starpod/src/layouts/Layout.astro`: when both env vars are set, the AT-URI is built with `getPublicationAtUri` from `@bryanguffey/astro-standard-site` and rendered in the head via a `Fragment` with `set:html`, just before the head slot. Gated entirely on the env vars, so consumers without standard.site are unaffected.

Verified by building the reference site with and without the env vars: with them set, the tag renders on the home page and episode pages; without them, output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)